### PR TITLE
fix apworld module data access

### DIFF
--- a/worlds/zfactor/__init__.py
+++ b/worlds/zfactor/__init__.py
@@ -93,7 +93,7 @@ class ZFWorld(World):
 
     def create_items(self) -> None:
         count_e = 0  # 12 Energy are progression , the rest are not
-        count_m = 0 # 4 Missiles are progression, the rest are not
+        count_m = 0  # 4 Missiles are progression, the rest are not
         count_s = 0  # 5 Supers are progression, the rest are not
         count_p = 0  # 5 PowerBombs are progression, the rest are not
         for name in names_for_item_pool():
@@ -145,9 +145,9 @@ class ZFWorld(World):
 
         patch_file_name = os.path.join(output_directory, f"{out_file_base}{ZFDeltaPatch.patch_file_ending}")
         patch = ZFDeltaPatch(patch_file_name,
-                                       player=self.player,
-                                       player_name=self.multiworld.player_name[self.player],
-                                       gen_data=make_gen_data(gen_data))
+                             player=self.player,
+                             player_name=self.multiworld.player_name[self.player],
+                             gen_data=make_gen_data(gen_data))
 
         patch.write()
 

--- a/worlds/zfactor/item.py
+++ b/worlds/zfactor/item.py
@@ -5,7 +5,7 @@ from BaseClasses import Item, ItemClassification as IC
 
 from .config import base_id
 
-from .zfactor_randomizer.item import Item as ZFItem, Items
+from .zfactor_randomizer.item import Item as ZFInternalItem, Items
 from .zfactor_randomizer.fillAssumed import FillAssumed
 
 classifications: Dict[str, IC] = defaultdict(lambda: IC.progression)
@@ -21,7 +21,7 @@ classifications.update({
 class ZFItem(Item):
     game = "Z Factor"
     __slots__ = ("zf_item",)
-    zf_item: ZFItem
+    zf_item: ZFInternalItem
 
     def __init__(self, name: str, player: int) -> None:
         classification = classifications[name]
@@ -30,7 +30,7 @@ class ZFItem(Item):
         self.zf_item = id_to_zf_item[code]
 
 
-local_id_to_zf_item: Dict[int, ZFItem] = {
+local_id_to_zf_item: Dict[int, ZFInternalItem] = {
     0x00: Items.Energy,
     0x01: Items.Missile,
     0x02: Items.Super,

--- a/worlds/zfactor/zfactor_randomizer/location.py
+++ b/worlds/zfactor/zfactor_randomizer/location.py
@@ -22,7 +22,7 @@ def pullCSV() -> dict[str, Location]:
     csvdict: dict[str, Location] = {}
 
     def commentfilter(line: str) -> bool:
-        return (line[0] != '#')
+        return (len(line) > 0 and line[0] != '#')
 
     csv_data = pkgutil.get_data(__name__, "ZF3.csv")
     if csv_data is None:

--- a/worlds/zfactor/zfactor_randomizer/location.py
+++ b/worlds/zfactor/zfactor_randomizer/location.py
@@ -1,5 +1,5 @@
 import csv
-import pathlib
+import pkgutil
 from typing import Optional, TypedDict, cast
 
 from .item import Item
@@ -24,17 +24,19 @@ def pullCSV() -> dict[str, Location]:
     def commentfilter(line: str) -> bool:
         return (line[0] != '#')
 
-    path = pathlib.Path(__file__).parent.resolve()
-    with open(path.joinpath("ZF3.csv"), 'r') as csvfile:
-        reader = csv.DictReader(filter(commentfilter, csvfile))
-        for row in reader:
-            row['altlocationids'] = row['altlocationids'].split(',')
-            row["index"] = int(row['index'])
-            row["roomid"] = int(row["roomid"], 16)
-            row["locationid"] = int(row["locationid"], 16)
-            row['altlocationids'] = [
-                int(locstr, 16) for locstr in row['altlocationids'] if locstr != '']
-            row['item'] = None
-            row['inlogic'] = False
-            csvdict[row["roomname"]] = cast(Location, row)
+    csv_data = pkgutil.get_data(__name__, "ZF3.csv")
+    if csv_data is None:
+        raise RuntimeError(f"unable to get zf location data from {__name__}")
+    csv_lines = csv_data.decode().splitlines()
+    reader = csv.DictReader(filter(commentfilter, csv_lines))
+    for row in reader:
+        row['altlocationids'] = row['altlocationids'].split(',')
+        row["index"] = int(row['index'])
+        row["roomid"] = int(row["roomid"], 16)
+        row["locationid"] = int(row["locationid"], 16)
+        row['altlocationids'] = [
+            int(locstr, 16) for locstr in row['altlocationids'] if locstr != '']
+        row['item'] = None
+        row['inlogic'] = False
+        csvdict[row["roomname"]] = cast(Location, row)
     return csvdict

--- a/worlds/zfactor/zfactor_randomizer/romWriter.py
+++ b/worlds/zfactor/zfactor_randomizer/romWriter.py
@@ -1,7 +1,7 @@
 import base64
 import enum
 import os
-import pathlib
+import pkgutil
 from typing import Optional, Union
 
 from .ips import patch
@@ -138,37 +138,19 @@ class RomWriter:
         #if len(self.rom_data) != 3178496:  # cliffhanger redux rom ?
         if len(self.rom_data) != 4194304:  # redesign !?!?
             if len(self.rom_data) == 3145728:  # vanilla SM
-                patch_path = pathlib.Path(__file__).parent.resolve()
-                with open(patch_path.joinpath('Zfactor_v1.3__uh_.ips'), 'rb') as file:
-                    patch_data = file.read()
-                self.rom_data = patch(self.rom_data, patch_data)
-
-                #adding other Z-factor rando patches
-                patch_path = pathlib.Path(__file__).parent.resolve()
-                with open(patch_path.joinpath('Patches/Level Patch.IPS'), 'rb') as file:
-                    patch_data = file.read()
-                self.rom_data = patch(self.rom_data, patch_data)
-
-                patch_path = pathlib.Path(__file__).parent.resolve()
-                with open(patch_path.joinpath('Patches/Zebes Awakens Patch.IPS'), 'rb') as file:
-                    patch_data = file.read()
-                self.rom_data = patch(self.rom_data, patch_data)
-
-                patch_path = pathlib.Path(__file__).parent.resolve()
-                with open(patch_path.joinpath('Patches/max_ammo_display.ips'), 'rb') as file:
-                    patch_data = file.read()
-                self.rom_data = patch(self.rom_data, patch_data)
-
-                patch_path = pathlib.Path(__file__).parent.resolve()
-                with open(patch_path.joinpath('Patches/Disable Suit Animation.IPS'), 'rb') as file:
-                    patch_data = file.read()
-                self.rom_data = patch(self.rom_data, patch_data)
-
-                patch_path = pathlib.Path(__file__).parent.resolve()
-                with open(patch_path.joinpath('Patches/JAMMorphingBallFix.IPS'), 'rb') as file:
-                    patch_data = file.read()
-                self.rom_data = patch(self.rom_data, patch_data)
-
+                ips_patches = (
+                    'Zfactor_v1.3__uh_.ips',
+                    'Patches/Level Patch.IPS',
+                    'Patches/Zebes Awakens Patch.IPS',
+                    'Patches/max_ammo_display.ips',
+                    'Patches/Disable Suit Animation.IPS',
+                    'Patches/JAMMorphingBallFix.IPS',
+                )
+                for patch_path in ips_patches:
+                    patch_data = pkgutil.get_data(__name__, patch_path)
+                    if patch_data is None:
+                        raise RuntimeError(f"unable to read {patch_path} from {__name__}")
+                    self.rom_data = patch(self.rom_data, patch_data)
 
                 #assert len(self.rom_data) == 4194304, f"patch made file {len(self.rom_data)}"
                 #assert len(self.rom_data) == 3178496, f"patch made file {len(self.rom_data)}" #CR


### PR DESCRIPTION
## What is this fixing or adding?

In an apworld, the Python function `open` doesn't work for files inside the Python package.
The best way to get data from inside a Python package is `pkgutil.get_data`

## How was this tested?

generated a seed and looked at the spoiler - didn't patch or play